### PR TITLE
Added public get method for error message at RequestError

### DIFF
--- a/library/src/main/java/quickutils/core/rest/RequestError.java
+++ b/library/src/main/java/quickutils/core/rest/RequestError.java
@@ -32,7 +32,8 @@ public class RequestError extends Exception {
     RequestError(NetworkResponse response) {
         this.errorCode = response.statusCode;
         this.headers = response.headers;
-        this.errorMessage = response.toString();
+        if(response.data != null)
+            this.errorMessage = new String(response.data);
     }
 
 

--- a/library/src/main/java/quickutils/core/rest/RequestError.java
+++ b/library/src/main/java/quickutils/core/rest/RequestError.java
@@ -26,6 +26,7 @@ public class RequestError extends Exception {
     public final static int REQUEST_RESPONSE_RESET_PASSWORD_SUCCESS = 204;
 
     final int errorCode;
+    private String errorMessage;
     final Map<String, String> headers;
 
     RequestError(NetworkResponse response) {
@@ -34,7 +35,6 @@ public class RequestError extends Exception {
         this.errorMessage = response.toString();
     }
 
-    private String errorMessage;
 
     RequestError(String response) {
         this.errorCode = REQUEST_RESPONSE_NOT_OK;
@@ -43,8 +43,13 @@ public class RequestError extends Exception {
         QuickUtils.log.e("ATTENTION: " + this.errorMessage);
     }
 
+
     public int getErrorCode() {
         return errorCode;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
     }
 
     public Map<String, String> getHeaders() {


### PR DESCRIPTION
The RequestError constructor initializes the errorMessage field, but the class does not have a public method for accessing this value, making impossible to the rest api access the result of the request
